### PR TITLE
refactor: rename parameter in isValidLength function for clarity

### DIFF
--- a/src/internal.go
+++ b/src/internal.go
@@ -12,8 +12,8 @@ func isValidEmail(email string) bool {
 	return validateEmailRegex.MatchString(email)
 }
 
-func isValidLength(entry string, minLength int, maxLength int) bool {
-	if len(entry) < minLength || len(entry) > maxLength {
+func isValidLength(input string, minLength int, maxLength int) bool {
+	if len(input) < minLength || len(input) > maxLength {
 		return false
 	}
 	return true


### PR DESCRIPTION
This pull request includes a minor change to the `isValidLength` function in the `src/internal.go` file. The change involves renaming a parameter for clarity.

* [`src/internal.go`](diffhunk://#diff-a84a2c5593a99635610eb07ce1868f88d6d3ab4d493de6252bc7fd159ed7f5f9L15-R16): Renamed the `entry` parameter to `input` in the `isValidLength` function for better readability.